### PR TITLE
Reversed depth buffer

### DIFF
--- a/core/camera/camera.go
+++ b/core/camera/camera.go
@@ -55,8 +55,8 @@ func (cam *camera) Name() string { return "Camera" }
 // Unproject screen space coordinates into world space
 func (cam *camera) Unproject(pos vec3.T) vec3.T {
 	// screen space -> clip space
-	pos.Y = 1 - pos.Y
-	pos = pos.Scaled(2).Sub(vec3.One)
+	pos.X = 2*pos.X - 1
+	pos.Y = 2*(1-pos.Y) - 1
 
 	// unproject to world space by multiplying inverse view-projection
 	return cam.vpi.TransformPoint(pos)
@@ -69,7 +69,7 @@ func (cam *camera) Update(dt float32) {
 func (cam *camera) PreDraw(args render.Args) error {
 	// update view & view-projection matrices
 	aspect := float32(args.Viewport.Width) / float32(args.Viewport.Height)
-	cam.proj = mat4.PerspectiveLH(cam.fov, aspect, cam.near, cam.far)
+	cam.proj = mat4.PerspectiveVK(cam.fov, aspect, cam.near, cam.far)
 
 	// Calculate new view matrix based on position & forward vector
 	// why is this different from the parent objects world matrix?

--- a/core/camera/frustum.go
+++ b/core/camera/frustum.go
@@ -14,14 +14,14 @@ type Frustum struct {
 }
 
 var ndc_corners = vec3.Array{
-	vec3.New(-1, 1, -1),  // NTL
-	vec3.New(1, 1, -1),   // NTR
-	vec3.New(-1, -1, -1), // NBL
-	vec3.New(1, -1, -1),  // NBR
-	vec3.New(-1, 1, 1),   // FTL
-	vec3.New(1, 1, 1),    // FTR
-	vec3.New(-1, -1, 1),  // FBL
-	vec3.New(1, -1, 1),   // FBR
+	vec3.New(-1, 1, 1),  // NTL
+	vec3.New(1, 1, 1),   // NTR
+	vec3.New(-1, -1, 1), // NBL
+	vec3.New(1, -1, 1),  // NBR
+	vec3.New(-1, 1, 0),  // FTL
+	vec3.New(1, 1, 0),   // FTR
+	vec3.New(-1, -1, 0), // FBL
+	vec3.New(1, -1, 0),  // FBR
 }
 
 // NewFrustum creates a view frustum from an inverse view projection matrix by unprojecting the corners of the NDC cube.

--- a/core/light/directional.go
+++ b/core/light/directional.go
@@ -33,7 +33,7 @@ func (lit *dirlight) LightDescriptor() Descriptor {
 	position := lit.Direction.Scaled(-1).Normalized() // turn direction into a position
 
 	// these calculations will need to know about the camera frustum later
-	lp := mat4.OrthographicLH(-16, 20, -10, 30, -20, 30)
+	lp := mat4.OrthographicVK(-16, 20, -10, 30, -20, 30)
 	lv := mat4.LookAtLH(position, vec3.Zero)
 	lvp := lp.Mul(&lv)
 

--- a/core/window/backend.go
+++ b/core/window/backend.go
@@ -68,6 +68,9 @@ func (b *OpenGLBackend) GlfwSetup(w *glfw.Window, args Args) error {
 		}
 	}
 
+	// set depth values to 0-1 instead of -1 to 1
+	gl.ClipControl(gl.LOWER_LEFT, gl.ZERO_TO_ONE)
+
 	return nil
 }
 

--- a/engine/deferred/light_pass.go
+++ b/engine/deferred/light_pass.go
@@ -161,7 +161,7 @@ func (p *LightPass) FitLightToCamera(vpi mat4.T, desc *light.Descriptor) {
 	zmin := float32(-100)
 	zmax := float32(100)
 
-	desc.Projection = mat4.Orthographic(
+	desc.Projection = mat4.OrthographicVK(
 		math.Snap(lfst.Center.X-maxExtent, snap), math.Snap(lfst.Center.X+maxExtent, snap),
 		math.Snap(lfst.Center.Y-maxExtent, snap), math.Snap(lfst.Center.Y+maxExtent, snap),
 		zmin, zmax)

--- a/engine/gui_pass.go
+++ b/engine/gui_pass.go
@@ -27,7 +27,7 @@ func (g *GuiPass) Draw(args render.Args, scene object.T) {
 	scale := width / float32(args.Viewport.Width)
 
 	// setup viewport
-	proj := mat4.OrthographicLH(0, width, height, 0, 1000, -1000)
+	proj := mat4.OrthographicVK(0, width, height, 0, 1000, -1000)
 	view := mat4.Scale(vec3.New(scale, scale, 1))
 	vp := proj.Mul(&view)
 

--- a/gui/widget/rect/rect.go
+++ b/gui/widget/rect/rect.go
@@ -53,7 +53,7 @@ func (f *rect) Draw(args render.Args) {
 
 	for _, child := range f.children {
 		// calculate child tranasform
-		pos := vec3.Extend(child.Position(), -1)
+		pos := vec3.Extend(child.Position(), 1)
 		transform := mat4.Translate(pos)
 		childArgs := args
 		childArgs.Transform = transform.Mul(&args.Transform)

--- a/math/mat4/project.go
+++ b/math/mat4/project.go
@@ -7,7 +7,7 @@ import (
 	mgl "github.com/go-gl/mathgl/mgl32"
 )
 
-// Orthographic generates a right-handed orthographic projection matrix.
+// OrthographicVK generates a right-handed orthographic projection matrix.
 // Outputs depth values in the range [-1, 1]
 func Orthographic(left, right, bottom, top, near, far float32) T {
 	rml, tmb, fmn := (right - left), (top - bottom), (far - near)
@@ -20,7 +20,7 @@ func Orthographic(left, right, bottom, top, near, far float32) T {
 	}
 }
 
-// OrthographicLH generates a left-handed orthographic projection matrix.
+// OrthographicVK generates a left-handed orthographic projection matrix.
 // Outputs depth values in the range [-1, 1]
 func OrthographicLH(left, right, bottom, top, near, far float32) T {
 	rml, tmb, fmn := (right - left), (top - bottom), (far - near)

--- a/render/backend/gl/gl_framebuffer/gl_geometrybuffer.go
+++ b/render/backend/gl/gl_framebuffer/gl_geometrybuffer.go
@@ -65,5 +65,5 @@ func (g *glgeombuf) SampleDepth(p vec2.T) (float32, bool) {
 	g.Bind()
 	x, y := int(p.X), int(p.Y)
 	depth, _ := g.T.SampleDepth(vec2.NewI(x, g.depth.Height()-y-1))
-	return depth, depth != 0.0
+	return depth, depth != 1.0
 }


### PR DESCRIPTION
- Increases depth buffer precision by using a reversed depth range, [1, 0] instead of [-1, 1]

**Breaks compatibility with MacOS due to the use of `glClipControl`. Kept for reference`**